### PR TITLE
Updated ms, efg quantity units

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -16,7 +16,7 @@ jobs:
         uv sync --all-extras
     - name: Test with pytest
       run: |
-        uv run --with coverage coverage run -m pytest -sv
+        uv run --with coverage coverage run -m pytest -sv -m "not efg" #remove -m when 'a_u_efg' available in nomad-lab
     - name: Submit to coveralls
       continue-on-error: true
       env:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -16,7 +16,7 @@ jobs:
         uv sync --all-extras
     - name: Test with pytest
       run: |
-        uv run --with coverage coverage run -m pytest -sv --ignore=tests/schema_packages/test_schema_package.py
+        uv run --with coverage coverage run -m pytest -sv
     - name: Submit to coveralls
       continue-on-error: true
       env:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -16,7 +16,7 @@ jobs:
         uv sync --all-extras
     - name: Test with pytest
       run: |
-        uv run --with coverage coverage run -m pytest -sv -m "not efg" #remove -m when 'a_u_efg' available in nomad-lab
+        uv run --with coverage coverage run -m pytest -sv
     - name: Submit to coveralls
       continue-on-error: true
       env:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -16,7 +16,7 @@ jobs:
         uv sync --all-extras
     - name: Test with pytest
       run: |
-        uv run --with coverage coverage run -m pytest -sv
+        uv run --with coverage coverage run -m pytest -sv --ignore=tests/schema_packages/test_schema_package.py
     - name: Submit to coveralls
       continue-on-error: true
       env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,11 @@ dev = [
     "pydantic>=2.0,<2.11",
     "python-logstash"
 ]
+# remove marker when 'a_u_efg' is adde dto nomad-lab as EFG unit
+[tool.pytest.ini_options]
+markers = [
+    "efg: marks tests related to ElectricFieldGradient functionality"
+]
 
 [tool.uv]
 extra-index-url = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: MIT License",
@@ -16,7 +15,7 @@ name = "nomad-nmr-schema"
 description = "Schema plugin containing shared classes for NMR metadata"
 version = "0.1.0"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [
     { name = "Andrea Albino", email = "andrea.albino@physik.hu-berlin.de" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,7 @@ license = { file = "LICENSE" }
 dependencies = [
     "nomad-lab >= 1.4.1",
     "python-magic-bin; sys_platform == 'win32'",
-    "nomad-simulations @ git+https://github.com/nomad-coe/nomad-simulations.git@46ed5a5d0632eac22267c9d38e9a4c66f43a5b38",
-    "pint @ git+https://github.com/hgrecco/pint.git@master",
+    "nomad-simulations @ git+https://github.com/nomad-coe/nomad-simulations.git@develop",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,11 +46,6 @@ dev = [
     "pydantic>=2.0,<2.11",
     "python-logstash"
 ]
-# remove marker when 'a_u_efg' is adde dto nomad-lab as EFG unit
-[tool.pytest.ini_options]
-markers = [
-    "efg: marks tests related to ElectricFieldGradient functionality"
-]
 
 [tool.uv]
 extra-index-url = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,9 @@ maintainers = [
 ]
 license = { file = "LICENSE" }
 dependencies = [
-    "nomad-lab >= 1.4.1",
+    "nomad-lab == 1.4.2",
     "python-magic-bin; sys_platform == 'win32'",
-    "nomad-simulations @ git+https://github.com/nomad-coe/nomad-simulations.git@develop",
+    "nomad-simulations @ git+https://github.com/nomad-coe/nomad-simulations.git@46ed5a5d0632eac22267c9d38e9a4c66f43a5b38",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,10 @@ maintainers = [
 ]
 license = { file = "LICENSE" }
 dependencies = [
-    "nomad-lab >= 1.3.15",
+    # "nomad-lab >= 1.3.15",
+    #Temporary pint units patch for nomad-lab, 
+    #TODO: revert back to central nomad-lab when EFG units are included.
+    "nomad-lab @ git+https://github.com/CCP-NC/nomad-FAIR-nmr-units-patch.git@main",
     "python-magic-bin; sys_platform == 'win32'",
     "nomad-simulations @ git+https://github.com/nomad-coe/nomad-simulations.git@46ed5a5d0632eac22267c9d38e9a4c66f43a5b38",
     "pint @ git+https://github.com/hgrecco/pint.git@master",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,7 @@ maintainers = [
 ]
 license = { file = "LICENSE" }
 dependencies = [
-    # "nomad-lab >= 1.3.15",
-    #Temporary pint units patch for nomad-lab, 
-    #TODO: revert back to central nomad-lab when EFG units are included.
-    "nomad-lab @ git+https://github.com/CCP-NC/nomad-FAIR-nmr-units-patch.git@main",
+    "nomad-lab >= 1.4.1",
     "python-magic-bin; sys_platform == 'win32'",
     "nomad-simulations @ git+https://github.com/nomad-coe/nomad-simulations.git@46ed5a5d0632eac22267c9d38e9a4c66f43a5b38",
     "pint @ git+https://github.com/hgrecco/pint.git@master",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "nomad-lab >= 1.3.15",
     "python-magic-bin; sys_platform == 'win32'",
     "nomad-simulations @ git+https://github.com/nomad-coe/nomad-simulations.git@46ed5a5d0632eac22267c9d38e9a4c66f43a5b38",
-    "pint @ git+https://github.com/hgrecco/pint.git@main",
+    "pint @ git+https://github.com/hgrecco/pint.git@master",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: MIT License",
@@ -15,7 +16,7 @@ name = "nomad-nmr-schema"
 description = "Schema plugin containing shared classes for NMR metadata"
 version = "0.1.0"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 authors = [
     { name = "Andrea Albino", email = "andrea.albino@physik.hu-berlin.de" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "nomad-lab >= 1.3.15",
     "python-magic-bin; sys_platform == 'win32'",
     "nomad-simulations @ git+https://github.com/nomad-coe/nomad-simulations.git@46ed5a5d0632eac22267c9d38e9a4c66f43a5b38",
+    "pint @ git+https://github.com/hgrecco/pint.git@main",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ license = { file = "LICENSE" }
 dependencies = [
     "nomad-lab == 1.4.2",
     "python-magic-bin; sys_platform == 'win32'",
-    "nomad-simulations @ git+https://github.com/nomad-coe/nomad-simulations.git@46ed5a5d0632eac22267c9d38e9a4c66f43a5b38",
+    "nomad-simulations @ git+https://github.com/nomad-coe/nomad-simulations.git@develop",
 ]
 
 [project.urls]

--- a/src/nomad_nmr_schema/schema_packages/schema_package.py
+++ b/src/nomad_nmr_schema/schema_packages/schema_package.py
@@ -66,6 +66,7 @@ class MagneticShielding(PhysicalProperty):
         type=np.float64,
         shape=[3, 3],
         unit='ppm',
+        a_eln=dict(defaultDisplayUnit='ppm'),
         description="""
         Value of the magnetic shielding tensor per atom.
         """,
@@ -73,6 +74,7 @@ class MagneticShielding(PhysicalProperty):
     isotropy = Quantity(
         type=np.float64,
         unit='ppm',
+        a_eln=dict(defaultDisplayUnit='ppm'),
         description="""
         The isotropy component of the `MagneticShielding` tensor. The isotropy
         magnetic shielding is defined as the average of the three principal components
@@ -89,6 +91,7 @@ class MagneticShielding(PhysicalProperty):
     anisotropy = Quantity(
         type=np.float64,
         unit='ppm',
+        a_eln=dict(defaultDisplayUnit='ppm'),
         description="""
         The magnetic shielding anisotropy is defined as:
 
@@ -103,6 +106,7 @@ class MagneticShielding(PhysicalProperty):
     reduced_anisotropy = Quantity(
         type=np.float64,
         unit='ppm',
+        a_eln=dict(defaultDisplayUnit='ppm'),
         description="""
         The reduced anisotropy is defined as:
 
@@ -136,6 +140,7 @@ class MagneticShielding(PhysicalProperty):
     span = Quantity(
         type=np.float64,
         unit='ppm',
+        a_eln=dict(defaultDisplayUnit='ppm'),
         description="""
         The span is defined as:
 

--- a/src/nomad_nmr_schema/schema_packages/schema_package.py
+++ b/src/nomad_nmr_schema/schema_packages/schema_package.py
@@ -233,7 +233,7 @@ class ElectricFieldGradient(PhysicalProperty):
     value = Quantity(
         type=np.float64,
         shape=[3, 3],
-        unit='hartree / bohr ** 2 / elementary_charge',
+        unit='a_u_efg',
         description="""
         The electric field gradient (EFG) tensor in Hartree atomic units.
         The 'au' units from magres files refer to Hartree atomic units, not Rydberg
@@ -242,7 +242,7 @@ class ElectricFieldGradient(PhysicalProperty):
     )
     Vzz = Quantity(
         type=np.float64,
-        unit='hartree / bohr ** 2 / elementary_charge',
+        unit='a_u_efg',
         description="""
         Largest (absolute) eigenvalue of the EFG tensor in Hartree atomic units.
         The 'au' units from magres files refer to Hartree atomic units, not Rydberg

--- a/src/nomad_nmr_schema/schema_packages/schema_package.py
+++ b/src/nomad_nmr_schema/schema_packages/schema_package.py
@@ -233,20 +233,20 @@ class ElectricFieldGradient(PhysicalProperty):
     value = Quantity(
         type=np.float64,
         shape=[3, 3],
-        unit='volt / meter ** 2',
+        unit='hartree / bohr ** 2 / elementary_charge',
         description="""
-        The electric field gradient (EFG) tensor. The 'au' units from magres files refer
-        to Hartree atomic units, not Rydberg atomic units. The magres parser scales
-        tensor values by 9.717362e21 to express the tensors in 'V/m^2'.
+        The electric field gradient (EFG) tensor in Hartree atomic units.
+        The 'au' units from magres files refer to Hartree atomic units, not Rydberg
+        atomic units.
         """,
     )
     Vzz = Quantity(
         type=np.float64,
-        unit='volt / meter ** 2',
+        unit='hartree / bohr ** 2 / elementary_charge',
         description="""
-        Largest (absolute)eigenvalue of the EFG tensor. The 'au' units from magres files
-        refer to Hartree atomic units, not Rydberg atomic units. The magres parser
-        scales tensor values by 9.717362e21 to express the tensors in 'V/m^2'.
+        Largest (absolute) eigenvalue of the EFG tensor in Hartree atomic units.
+        The 'au' units from magres files refer to Hartree atomic units, not Rydberg
+        atomic units.
         """,
     )
 

--- a/src/nomad_nmr_schema/schema_packages/schema_package.py
+++ b/src/nomad_nmr_schema/schema_packages/schema_package.py
@@ -60,20 +60,19 @@ class MagneticShielding(PhysicalProperty):
     correspond to an atom in the unit cell.
     The specific atom is known by defining the reference to the specific `AtomsState`
     under `ModelSystem.cell.atoms_state` using `entity_ref`.
-    TODO: these should be ppm
     """
 
     value = Quantity(
         type=np.float64,
         shape=[3, 3],
-        unit='dimensionless',
+        unit='ppm',
         description="""
         Value of the magnetic shielding tensor per atom.
         """,
     )
     isotropy = Quantity(
         type=np.float64,
-        unit='dimensionless',
+        unit='ppm',
         description="""
         The isotropy component of the `MagneticShielding` tensor. The isotropy
         magnetic shielding is defined as the average of the three principal components
@@ -89,7 +88,7 @@ class MagneticShielding(PhysicalProperty):
     )
     anisotropy = Quantity(
         type=np.float64,
-        unit='dimensionless',
+        unit='ppm',
         description="""
         The magnetic shielding anisotropy is defined as:
 
@@ -103,7 +102,7 @@ class MagneticShielding(PhysicalProperty):
     )
     reduced_anisotropy = Quantity(
         type=np.float64,
-        unit='dimensionless',
+        unit='ppm',
         description="""
         The reduced anisotropy is defined as:
 
@@ -136,7 +135,7 @@ class MagneticShielding(PhysicalProperty):
     )
     span = Quantity(
         type=np.float64,
-        unit='dimensionless',
+        unit='ppm',
         description="""
         The span is defined as:
 

--- a/src/nomad_nmr_schema/schema_packages/tensor_utils.py
+++ b/src/nomad_nmr_schema/schema_packages/tensor_utils.py
@@ -4,7 +4,7 @@ NMR tensor as well as its representation in multiple conventions
 """
 
 import warnings
-from enum import Enum
+from enum import StrEnum
 
 import numpy as np
 
@@ -17,7 +17,7 @@ TENSOR_DIMENSION: int = 3
 EIGENVALUE_TRIPLET_SIZE: int = 2
 
 
-class TensorConvention(str, Enum):
+class TensorConvention(StrEnum):
     Haeberlen = 'h'
     Increasing = 'i'
     Decreasing = 'd'

--- a/tests/schema_packages/test_schema_package.py
+++ b/tests/schema_packages/test_schema_package.py
@@ -15,14 +15,8 @@ from nomad_nmr_schema.schema_packages.schema_package import (
     resolve_name_from_entity_ref,
 )
 
-# Revert previous import when 'a_u_efg' unit is added to nomad-lab
-# Conditional import for ElectricFieldGradient to handle missing 'a_u_efg' unit
-try:
-    from nomad_nmr_schema.schema_packages.schema_package import ElectricFieldGradient
-    HAS_EFG = True
-except ImportError:
-    HAS_EFG = False
-    ElectricFieldGradient = None
+# TODO: Re-enable when 'a_u_efg' unit is available in nomad-lab
+# from nomad_nmr_schema.schema_packages.schema_package import ElectricFieldGradient
 from nomad_nmr_schema.schema_packages.tensor_utils import (
     NMRTensor,
     TensorConvention,
@@ -104,39 +98,33 @@ def check_magnetic_shielding(data):
     )
 
 
-# Remove markers when 'a_u_efg' unit is added to nomad-lab and
-# ElectricFieldGradient functionality is available
-@pytest.mark.efg
-@pytest.mark.skipif(
-    not HAS_EFG,
-    reason="ElectricFieldGradient not available due to missing 'a_u_efg' unit"
-)
-def check_electric_field_gradient(data):
-    # Assert that the parsed magnetic shielding tensor matches the expected value
-    assert np.array_equal(data.value.m, EXPECTED_GRADIENT_VALUE), (
-        f'Electric Field Gradient tensor mismatch: '
-        f'expected {EXPECTED_GRADIENT_VALUE}, got {data.value.m}'
-    )
-
-    # Convert the tensor to a numpy array and create an NMRTensor for derived property
-    # calculations
-    matrix = np.array(data.value.m, dtype=float)
-    tensor = NMRTensor(matrix, TensorConvention.NQR)
-
-    # Assign derived tensor properties to the data object for further checks
-    data.Vzz = tensor.eigenvalues[2]
-    data.asymmetry = tensor.asymmetry
-
-    # Assert that all derived properties match the expected values within a tolerance
-    assert data.Vzz.m == pytest.approx(EXPECTED_GRADIENT_DERIVED['Vzz'], abs=1e-2)
-    assert data.asymmetry.m == pytest.approx(
-        EXPECTED_GRADIENT_DERIVED['asymmetry'], abs=1e-2
-    )
-
-    # Ensure asymmetry is within the physically meaningful range [0, 1]
-    assert 0 <= data.asymmetry.m <= 1, (
-        f'Asymmetry value {data.asymmetry.m} is not between 0 and 1'
-    )
+# TODO: Re-enable when 'a_u_efg' unit is available in nomad-lab  
+# def check_electric_field_gradient(data):
+#     # Assert that the parsed magnetic shielding tensor matches the expected value
+#     assert np.array_equal(data.value.m, EXPECTED_GRADIENT_VALUE), (
+#         f'Electric Field Gradient tensor mismatch: '
+#         f'expected {EXPECTED_GRADIENT_VALUE}, got {data.value.m}'
+#     )
+# 
+#     # Convert the tensor to a numpy array and create an NMRTensor for derived property
+#     # calculations
+#     matrix = np.array(data.value.m, dtype=float)
+#     tensor = NMRTensor(matrix, TensorConvention.NQR)
+# 
+#     # Assign derived tensor properties to the data object for further checks
+#     data.Vzz = tensor.eigenvalues[2]
+#     data.asymmetry = tensor.asymmetry
+# 
+#     # Assert that all derived properties match the expected values within a tolerance
+#     assert data.Vzz.m == pytest.approx(EXPECTED_GRADIENT_DERIVED['Vzz'], abs=1e-2)
+#     assert data.asymmetry.m == pytest.approx(
+#         EXPECTED_GRADIENT_DERIVED['asymmetry'], abs=1e-2
+#     )
+# 
+#     # Ensure asymmetry is within the physically meaningful range [0, 1]
+#     assert 0 <= data.asymmetry.m <= 1, (
+#         f'Asymmetry value {data.asymmetry.m} is not between 0 and 1'
+#     )
 
 
 def check_indirect_spin_spin_coupling(data):
@@ -257,15 +245,10 @@ def test_schema_package(test_file):
     # Test Magnetic Shielding
     elif name == 'MagneticShielding':
         check_magnetic_shielding(entry_archive.data)
-    # Test Electric Field Gradient
-    elif name == 'ElectricFieldGradient':
-        # Remove skip condition when 'a_u_efg' unit is added to nomad-lab and
-        # ElectricFieldGradient functionality is available
-        if not HAS_EFG:
-            pytest.skip(
-                "ElectricFieldGradient not available due to missing 'a_u_efg' unit"
-            )
-        check_electric_field_gradient(entry_archive.data)
+    # TODO: Re-enable when 'a_u_efg' unit is available in nomad-lab
+    # # Test Electric Field Gradient  
+    # elif name == 'ElectricFieldGradient':
+    #     check_electric_field_gradient(entry_archive.data)
     # Test Indirect Spin-Spin Coupling
     elif name == 'IndirectSpinSpinCoupling':
         check_indirect_spin_spin_coupling(entry_archive.data)

--- a/tests/schema_packages/test_schema_package.py
+++ b/tests/schema_packages/test_schema_package.py
@@ -14,8 +14,6 @@ from nomad_nmr_schema.schema_packages.schema_package import (
     MagneticShielding,
     resolve_name_from_entity_ref,
 )
-
-from nomad_nmr_schema.schema_packages.schema_package import ElectricFieldGradient
 from nomad_nmr_schema.schema_packages.tensor_utils import (
     NMRTensor,
     TensorConvention,
@@ -128,7 +126,7 @@ def check_electric_field_gradient(data):
 def check_indirect_spin_spin_coupling(data):
     # Assert that the parsed magnetic shielding tensor matches the expected value
     assert np.array_equal(data.value.m, EXPECTED_ISC_VALUE), (
-        f'Electric Field Gradient tensor mismatch: '
+        f'Indirect Spin-Spin Coupling tensor mismatch: '
         f'expected {EXPECTED_ISC_VALUE}, got {data.value.m}'
     )
 

--- a/tests/schema_packages/test_schema_package.py
+++ b/tests/schema_packages/test_schema_package.py
@@ -14,6 +14,15 @@ from nomad_nmr_schema.schema_packages.schema_package import (
     MagneticShielding,
     resolve_name_from_entity_ref,
 )
+
+# Revert previous import when 'a_u_efg' unit is added to nomad-lab
+# Conditional import for ElectricFieldGradient to handle missing 'a_u_efg' unit
+try:
+    from nomad_nmr_schema.schema_packages.schema_package import ElectricFieldGradient
+    HAS_EFG = True
+except ImportError:
+    HAS_EFG = False
+    ElectricFieldGradient = None
 from nomad_nmr_schema.schema_packages.tensor_utils import (
     NMRTensor,
     TensorConvention,
@@ -95,6 +104,13 @@ def check_magnetic_shielding(data):
     )
 
 
+# Remove markers when 'a_u_efg' unit is added to nomad-lab and
+# ElectricFieldGradient functionality is available
+@pytest.mark.efg
+@pytest.mark.skipif(
+    not HAS_EFG,
+    reason="ElectricFieldGradient not available due to missing 'a_u_efg' unit"
+)
 def check_electric_field_gradient(data):
     # Assert that the parsed magnetic shielding tensor matches the expected value
     assert np.array_equal(data.value.m, EXPECTED_GRADIENT_VALUE), (
@@ -243,6 +259,12 @@ def test_schema_package(test_file):
         check_magnetic_shielding(entry_archive.data)
     # Test Electric Field Gradient
     elif name == 'ElectricFieldGradient':
+        # Remove skip condition when 'a_u_efg' unit is added to nomad-lab and
+        # ElectricFieldGradient functionality is available
+        if not HAS_EFG:
+            pytest.skip(
+                "ElectricFieldGradient not available due to missing 'a_u_efg' unit"
+            )
         check_electric_field_gradient(entry_archive.data)
     # Test Indirect Spin-Spin Coupling
     elif name == 'IndirectSpinSpinCoupling':

--- a/tests/schema_packages/test_schema_package.py
+++ b/tests/schema_packages/test_schema_package.py
@@ -15,8 +15,7 @@ from nomad_nmr_schema.schema_packages.schema_package import (
     resolve_name_from_entity_ref,
 )
 
-# TODO: Re-enable when 'a_u_efg' unit is available in nomad-lab
-# from nomad_nmr_schema.schema_packages.schema_package import ElectricFieldGradient
+from nomad_nmr_schema.schema_packages.schema_package import ElectricFieldGradient
 from nomad_nmr_schema.schema_packages.tensor_utils import (
     NMRTensor,
     TensorConvention,
@@ -24,9 +23,8 @@ from nomad_nmr_schema.schema_packages.tensor_utils import (
 from tests.schema_packages.expected_values import (
     EXPECTED_DELTA_G_PARATEC_VALUE,
     EXPECTED_DELTA_G_VALUE,
-    # TODO: Re-enable when EFG tests are uncommented
-    # EXPECTED_GRADIENT_DERIVED,
-    # EXPECTED_GRADIENT_VALUE,
+    EXPECTED_GRADIENT_DERIVED,
+    EXPECTED_GRADIENT_VALUE,
     EXPECTED_HYPERFINE_DIPOLAR_VALUE,
     EXPECTED_HYPERFINE_FERMI_CONTACT_VALUE,
     EXPECTED_ISC_DERIVED,
@@ -99,33 +97,32 @@ def check_magnetic_shielding(data):
     )
 
 
-# TODO: Re-enable when 'a_u_efg' unit is available in nomad-lab  
-# def check_electric_field_gradient(data):
-#     # Assert that the parsed magnetic shielding tensor matches the expected value
-#     assert np.array_equal(data.value.m, EXPECTED_GRADIENT_VALUE), (
-#         f'Electric Field Gradient tensor mismatch: '
-#         f'expected {EXPECTED_GRADIENT_VALUE}, got {data.value.m}'
-#     )
-# 
-#     # Convert the tensor to a numpy array and create an NMRTensor for derived property
-#     # calculations
-#     matrix = np.array(data.value.m, dtype=float)
-#     tensor = NMRTensor(matrix, TensorConvention.NQR)
-# 
-#     # Assign derived tensor properties to the data object for further checks
-#     data.Vzz = tensor.eigenvalues[2]
-#     data.asymmetry = tensor.asymmetry
-# 
-#     # Assert that all derived properties match the expected values within a tolerance
-#     assert data.Vzz.m == pytest.approx(EXPECTED_GRADIENT_DERIVED['Vzz'], abs=1e-2)
-#     assert data.asymmetry.m == pytest.approx(
-#         EXPECTED_GRADIENT_DERIVED['asymmetry'], abs=1e-2
-#     )
-# 
-#     # Ensure asymmetry is within the physically meaningful range [0, 1]
-#     assert 0 <= data.asymmetry.m <= 1, (
-#         f'Asymmetry value {data.asymmetry.m} is not between 0 and 1'
-#     )
+def check_electric_field_gradient(data):
+    # Assert that the parsed magnetic shielding tensor matches the expected value
+    assert np.array_equal(data.value.m, EXPECTED_GRADIENT_VALUE), (
+        f'Electric Field Gradient tensor mismatch: '
+        f'expected {EXPECTED_GRADIENT_VALUE}, got {data.value.m}'
+    )
+
+    # Convert the tensor to a numpy array and create an NMRTensor for derived property
+    # calculations
+    matrix = np.array(data.value.m, dtype=float)
+    tensor = NMRTensor(matrix, TensorConvention.NQR)
+
+    # Assign derived tensor properties to the data object for further checks
+    data.Vzz = tensor.eigenvalues[2]
+    data.asymmetry = tensor.asymmetry
+
+    # Assert that all derived properties match the expected values within a tolerance
+    assert data.Vzz.m == pytest.approx(EXPECTED_GRADIENT_DERIVED['Vzz'], abs=1e-2)
+    assert data.asymmetry.m == pytest.approx(
+        EXPECTED_GRADIENT_DERIVED['asymmetry'], abs=1e-2
+    )
+
+    # Ensure asymmetry is within the physically meaningful range [0, 1]
+    assert 0 <= data.asymmetry.m <= 1, (
+        f'Asymmetry value {data.asymmetry.m} is not between 0 and 1'
+    )
 
 
 def check_indirect_spin_spin_coupling(data):
@@ -246,10 +243,9 @@ def test_schema_package(test_file):
     # Test Magnetic Shielding
     elif name == 'MagneticShielding':
         check_magnetic_shielding(entry_archive.data)
-    # TODO: Re-enable when 'a_u_efg' unit is available in nomad-lab
-    # # Test Electric Field Gradient  
-    # elif name == 'ElectricFieldGradient':
-    #     check_electric_field_gradient(entry_archive.data)
+    # Test Electric Field Gradient  
+    elif name == 'ElectricFieldGradient':
+        check_electric_field_gradient(entry_archive.data)
     # Test Indirect Spin-Spin Coupling
     elif name == 'IndirectSpinSpinCoupling':
         check_indirect_spin_spin_coupling(entry_archive.data)

--- a/tests/schema_packages/test_schema_package.py
+++ b/tests/schema_packages/test_schema_package.py
@@ -24,8 +24,9 @@ from nomad_nmr_schema.schema_packages.tensor_utils import (
 from tests.schema_packages.expected_values import (
     EXPECTED_DELTA_G_PARATEC_VALUE,
     EXPECTED_DELTA_G_VALUE,
-    EXPECTED_GRADIENT_DERIVED,
-    EXPECTED_GRADIENT_VALUE,
+    # TODO: Re-enable when EFG tests are uncommented
+    # EXPECTED_GRADIENT_DERIVED,
+    # EXPECTED_GRADIENT_VALUE,
     EXPECTED_HYPERFINE_DIPOLAR_VALUE,
     EXPECTED_HYPERFINE_FERMI_CONTACT_VALUE,
     EXPECTED_ISC_DERIVED,


### PR DESCRIPTION
This PR updates the NMR schema plugin to improve unit handling for magnetic shielding and electric field gradient (EFG) quantities, along with dependency and code quality improvements. Changes include:

- Unit Standardisation:
  - Magnetic shielding quantities now use explicit 'ppm' units (was 'dimensionless').
  - EFG quantities now use Hartree atomic units ('a_u_efg') instead of 'V/m²', with updated documentation for clarity.
 
- Dependency Updates:
  - Upgraded nomad-lab dependency to version 1.4.2.
  - Updated nomad-simulations dependency to a specific commit for consistency.
  - Temporary addition and later removal of the pint package for unit handling.
 
- Python Version and Linting:
  - Adjusted supported Python versions for compatibility.
  - Applied ruff linting fixes and minor code cleanups.
 
- Testing:
  - Re-enabled and updated EFG-related tests.
  - Improved test assertions and error messages for clarity.
 
- Other Improvements:
  - Switched from Enum to StrEnum for tensor conventions.
  - Improved docstrings and comments for maintainability.

**Files Changed:**
pyproject.toml: Dependency and version updates.
src/nomad_nmr_schema/schema_packages/schema_package.py: Major unit and docstring changes for NMR quantities.
src/nomad_nmr_schema/schema_packages/tensor_utils.py: Enum improvements.
tests/schema_packages/test_schema_package.py: Test updates and fixes.