### PR TITLE
cap greenlet dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
 extra-index-url = [
   "https://gitlab.mpcdf.mpg.de/api/v4/projects/2187/packages/pypi/simple",
 ]
+constraint-dependencies = ["greenlet<3.5.0"]
 
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,9 @@ dev = [
 extra-index-url = [
   "https://gitlab.mpcdf.mpg.de/api/v4/projects/2187/packages/pypi/simple",
 ]
-constraint-dependencies = ["greenlet<3.5.0"]
+required-environments = [
+  "sys_platform == 'linux' and platform_machine == 'x86_64'",
+]
 
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.


### PR DESCRIPTION
Hi @JFRudzinski and @ladinesa,

I recently merged a branch to main and published a release, but I encountered an error in the install-and-test workflow in Actions. Please see: https://github.com/FAIRmat-NFDI/nomad-schema-plugin-nmr/actions/runs/24994804042/job/73188888062

I initially capped the dependency greenlet's version to below 3.5.0 that I got the error for, hoping this generic definition will avoid future errors. But I realised this is a blunt solution and instead going with the recommended course of action of adding
```
required-environments = [
  "sys_platform == 'linux' and platform_machine == 'x86_64'",
]
```
to tool.uv might offer a broader solution without constraining the dependency for future releases. Could you kindly review and approve?